### PR TITLE
Update to 0.4.1 & fix missing libcudart

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,18 +58,12 @@ parts:
     source: ./snap/local
     organize:
       snap_launcher.sh: bin/snap_launcher.sh
-  patches:
-    plugin: dump
-    source: ./patches
-    prime:
-      - -*
   ollama:
     plugin: go
+    go-generate: ["./..."]
     source: https://github.com/ollama/ollama.git
     source-type: git
-    source-tag: v0.3.13
-    after:
-      - patches
+    source-tag: v0.4.1
     # build packages (not staged) because ollama copies in cudnn, cublas etc
     build-packages:
       - git
@@ -96,7 +90,5 @@ parts:
       last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
       craftctl set version="$(git describe --tags | sed 's/v//')"
     override-build: |
-      git apply $SNAPCRAFT_STAGE/llm/generate/gen_linux.sh.patch
-      go generate ./...
       craftctl default
       cp -r "${CRAFT_PART_BUILD}/dist/linux-${CRAFT_ARCH_BUILD_FOR}/lib" "${CRAFT_PART_INSTALL}/."

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -99,3 +99,4 @@ parts:
       git apply $SNAPCRAFT_STAGE/llm/generate/gen_linux.sh.patch
       go generate ./...
       craftctl default
+      cp -r "${CRAFT_PART_BUILD}/dist/linux-${CRAFT_ARCH_BUILD_FOR}/lib" "${CRAFT_PART_INSTALL}/."


### PR DESCRIPTION
The `libcudart` lib and others aren't staged leading to missing libraries. Possibly due to https://github.com/ollama/ollama/pull/5034. This PR copies the repo containing those lib to the `install` folder which seems to do the trick.

While at it, it also update to `0.4.1`.

Fix #2 .