### PR TITLE
fix arm64 build and prepare for automated version updates

### DIFF
--- a/.github/workflows/snap-build.yml
+++ b/.github/workflows/snap-build.yml
@@ -1,0 +1,24 @@
+name: Snap Build
+
+on:
+  pull_request:
+    types: [opened, reopened]    
+  workflow_dispatch:
+
+jobs:
+  build-amd64:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+    - uses: snapcore/action-build@v1
+  build-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+    - uses: snapcore/action-build@v1

--- a/.github/workflows/snap-build.yml
+++ b/.github/workflows/snap-build.yml
@@ -9,11 +9,20 @@ jobs:
   build-amd64:
     runs-on: ubuntu-24.04
     steps:
+    - uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         fetch-tags: true
     - uses: snapcore/action-build@v1
+      id: snapcraft
+    - uses: actions/upload-artifact@v4
+      with:
+        name: snap
+        path: ${{ steps.snapcraft.outputs.snap }}
+        retention-days: 5
   build-arm64:
     runs-on: ubuntu-24.04-arm
     steps:
@@ -22,3 +31,9 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
     - uses: snapcore/action-build@v1
+      id: snapcraft
+    - uses: actions/upload-artifact@v4
+      with:
+        name: snap
+        path: ${{ steps.snapcraft.outputs.snap }}
+        retention-days: 5

--- a/.github/workflows/snap-build.yml
+++ b/.github/workflows/snap-build.yml
@@ -9,7 +9,7 @@ jobs:
   build-amd64:
     runs-on: ubuntu-24.04
     steps:
-    - uses: jlumbroso/free-disk-space@main
+    - uses: jlumbroso/free-disk-space@3e0187054f9c4bc1f55a743792872df36b2d88e0
       with:
         tool-cache: true
     - uses: actions/checkout@v4

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 ---
 name: ollama
+version: v0.5.7
 base: core24
 summary: Get up and running with large language models locally.
 description: |
@@ -60,7 +61,7 @@ parts:
     plugin: go
     source: https://github.com/ollama/ollama.git
     source-type: git
-    source-tag: v0.5.7
+    source-tag: $SNAPCRAFT_PROJECT_VERSION
     # build packages (not staged) because ollama copies in cudnn, cublas etc
     build-packages:
       - git
@@ -68,15 +69,16 @@ parts:
       - cmake
       - sed
       - libcudnn9-cuda-12
-      - libcublas-12-6
       - libcudnn9-dev-cuda-12
-      - libcublas-dev-12-6
-      - cuda-cudart-dev-12-6
-      - cuda-driver-dev-12-6
-      - tensorrt-libs
-      - tensorrt-dev
-      - cuda-toolkit-12-6
-      - nvidia-cuda-dev
+      - on amd64:
+        - cuda-cudart-dev-12-6
+        - cuda-driver-dev-12-6
+        - cuda-toolkit-12-6
+        - nvidia-cuda-dev
+        - libcublas-12-6
+        - libcublas-dev-12-6
+        - tensorrt-libs
+        - tensorrt-dev
     build-snaps:
       - go/stable
     build-environment:
@@ -91,7 +93,8 @@ parts:
     plugin: nil
     stage-packages:
       - libcudnn9-cuda-12
-      - libcublas-12-6
-      - cuda-libraries-12-6
+      - on amd64:
+        - libcublas-12-6
+        - cuda-libraries-12-6
     stage:
       - -usr/local


### PR DESCRIPTION
Use advanced grammar to fix arm64 build, prepare for automated version updates, and added workflow to build snap on amd64 and arm64.