### PR TITLE
Add flash attention configuration key

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -6,4 +6,5 @@ snapctl set host=127.0.0.1:11434
 snapctl set models="$SNAP_COMMON/models"
 snapctl set origins="*://localhost"
 snapctl set cuda-visible-devices=""
+snapctl set flash-attention=0
 snapctl set debug=0

--- a/snap/local/snap_launcher.sh
+++ b/snap/local/snap_launcher.sh
@@ -5,6 +5,7 @@ OLLAMA_HOST=$(snapctl get host)
 OLLAMA_MODELS=$(snapctl get models)
 OLLAMA_ORIGINS=$(snapctl get origins)
 CUDA_VISIBLE_DEVICES_VALUE=$(snapctl get cuda-visible-devices)
+OLLAMA_FLASH_ATTENTION=$(snapctl get flash-attention)
 OLLAMA_DEBUG=$(snapctl get debug)
 
 if [ -n "$CUDA_VISIBLE_DEVICES_VALUE" ]; then


### PR DESCRIPTION
I couldn't find the Snap documentation to update it with the new settings.