### PR TITLE
Adds snap config option for setting OLLAMA_CONTEXT_LENGTH

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -7,3 +7,4 @@ snapctl set models="$SNAP_COMMON/models"
 snapctl set origins="*://localhost"
 snapctl set cuda-visible-devices=""
 snapctl set debug=0
+snapctl set context-length=""

--- a/snap/local/snap_launcher.sh
+++ b/snap/local/snap_launcher.sh
@@ -6,9 +6,14 @@ OLLAMA_MODELS=$(snapctl get models)
 OLLAMA_ORIGINS=$(snapctl get origins)
 CUDA_VISIBLE_DEVICES_VALUE=$(snapctl get cuda-visible-devices)
 OLLAMA_DEBUG=$(snapctl get debug)
+OPTIONAL_CONTEXT_LENGTH=$(snapctl get context-length)
 
 if [ -n "$CUDA_VISIBLE_DEVICES_VALUE" ]; then
     export CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES_VALUE
+fi
+
+if [ -n "$OPTIONAL_CONTEXT_LENGTH" ]; then
+    export OLLAMA_CONTEXT_LENGTH=$OPTIONAL_CONTEXT_LENGTH
 fi
 
 export OLLAMA_HOST OLLAMA_MODELS OLLAMA_ORIGINS OLLAMA_DEBUG


### PR DESCRIPTION
Noticed, incidentally via [aider documentation](https://aider.chat/docs/llms/ollama.html), that there is an `OLLAMA_CONTEXT_LENGTH` option available.