### PR TITLE
Add GPU-2404 support for Ubuntu Core 24

### DIFF
--- a/nvidia/gpu-wrapper
+++ b/nvidia/gpu-wrapper
@@ -1,0 +1,34 @@
+#!/bin/bash
+# GPU wrapper for Ollama - simplified version of docker-snap's gpu-2404-optional-wrapper
+
+set -e
+
+. "${SNAP}/usr/share/nvidia-container-toolkit/lib"
+
+# Classic systems don't need this wrapper
+if nvidia_support_classic; then
+    exec "$@"
+fi
+
+# Core systems with GPU support
+if nvidia_support_core; then
+    # If gpu-2404 is connected, use the provider wrapper
+    if snapctl is-connected gpu-2404; then
+        # Check if the provider wrapper exists
+        if [ -x "${SNAP}/gpu-2404/bin/gpu-2404-provider-wrapper" ]; then
+            exec "${SNAP}/gpu-2404/bin/gpu-2404-provider-wrapper" "$@"
+        else
+            echo "GPU-2404 connected but no provider wrapper found"
+        fi
+    fi
+    
+    # Core 22 systems don't require wrapper
+    if snapctl is-connected graphics-core22; then
+        exec "$@"
+    fi
+    
+    echo "INFO: GPU content provider not connected. Running without GPU acceleration."
+fi
+
+# Default: run without wrapper
+exec "$@"

--- a/nvidia/lib
+++ b/nvidia/lib
@@ -1,0 +1,145 @@
+#!/bin/bash
+# nvidia toolkit related setup funtions #
+
+U_MACHINE="$(uname -m)"
+U_OS="$(uname -o)"
+U_KERNEL="${U_OS##*/}"
+U_USERLAND="${U_OS%%/*}"
+
+ARCH_TRIPLET="${U_MACHINE}-${U_KERNEL,,}-${U_USERLAND,,}"
+
+nvidia_support_disabled() {
+    [ "$(snapctl get nvidia-support.disabled)" == "true" ]
+}
+
+nvidia_support_core() {
+    snapctl is-connected gpu-2404 || snapctl is-connected graphics-core22
+}
+
+nvidia_support_classic() {
+    # If the directory exists, we assume classic support is enabled then this returns true #
+    [ -L "/var/lib/snapd/hostfs/usr/lib/${ARCH_TRIPLET}/libcuda.so" ]
+}
+
+device_wait() {
+
+    COUNT=0
+    SLEEP=3
+    TRIES=10
+
+    echo "Waiting for device to become available: ${1}"
+
+    while [ ${COUNT} -le ${TRIES} ] ; do
+        echo "Checking device: ${COUNT}/${TRIES}"
+        test -c "${1}"
+        if [ $? -eq 0 ] ; then
+            echo "Device found"
+            return 0
+        fi
+        sleep $SLEEP
+        COUNT=$(($COUNT + 1))
+    done
+
+    echo "Device not found"
+    return 1
+
+}
+
+# Check if hardware is present - just exit if not #
+nvidia_hw_ensure() {
+    lspci -d 10de: | grep -q 'NVIDIA Corporation' || exit_inf "NVIDIA hardware not found"
+    echo "NVIDIA hardware detected: $(lspci -d 10de:)"
+}
+
+# Create any data dirs if missing #
+ensure_nvidia_data_dirs() {
+    mkdir -p "${SNAP_DATA}/etc/cdi"
+    mkdir -p "${SNAP_DATA}/etc/nvidia-container-runtime"
+}
+
+# Generate the CDI config #
+cdi_generate () {
+    # Allow configured device-name-strategy, or default to index [ default in nvidia-ctk ] #
+    CDI_DEVICE_NAME_STRATEGY="$(snapctl get nvidia-support.cdi.device-name-strategy)"
+    CDI_DEVICE_NAME_STRATEGY="${CDI_DEVICE_NAME_STRATEGY:-index}"
+
+    # Default CDI libs search path and shell path for install on core systems #
+    CONTENT_PATH="/usr"
+    
+    if [ -n "${NVIDIA_DRIVER_ROOT:-}" ]; then # UC24
+        # NVIDIA_DRIVER_ROOT comes from the pc-kernel snap, through mesa-2404
+        CONTENT_PATH="${NVIDIA_DRIVER_ROOT}/usr"
+    elif [ -d "${SNAP}/graphics/lib/${ARCH_TRIPLET}" ]; then # UC22
+        CONTENT_PATH="${SNAP}/graphics"
+    fi
+    echo "CONTENT_PATH=${CONTENT_PATH}"
+
+    # FIXME: if UC24, can we just rely on the wrapper env instead of these vars ?
+    CDI_LIB_SEARCH_PATH="${CONTENT_PATH}/lib/${ARCH_TRIPLET}"
+    CDI_CONFIG_SEARCH_PATH="${CONTENT_PATH}/share"
+    CDI_PATH="${PATH}:${CONTENT_PATH}/bin"
+
+    # Otherwise, if on classic and nvidia driver is installed, set hostfs for the CDI libs search path and shell path #
+    if nvidia_support_classic; then
+        CDI_LIB_SEARCH_PATH="/var/lib/snapd/hostfs/usr/lib/${ARCH_TRIPLET}"
+        CDI_CONFIG_SEARCH_PATH="/var/lib/snapd/hostfs/usr/share"
+        CDI_PATH="${PATH}:/var/lib/snapd/hostfs/usr/bin"
+    fi
+
+    # Generate the CDI spec
+    XDG_DATA_DIRS="${XDG_DATA_DIRS:-}:${CDI_CONFIG_SEARCH_PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${CDI_LIB_SEARCH_PATH}" PATH="${CDI_PATH}" \
+     "${SNAP}/usr/bin/nvidia-ctk" cdi generate \
+     --nvidia-ctk-path "${SNAP}/usr/bin/nvidia-ctk" \
+     --library-search-path "${CDI_LIB_SEARCH_PATH}" \
+     --device-name-strategy "${CDI_DEVICE_NAME_STRATEGY}" \
+     --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+
+    if nvidia_support_classic; then
+        # Replace container path for binaries such as nvidia-smi to make them discoverable from the default PATH
+        sed -i "s|containerPath: /var/lib/snapd/hostfs/usr/bin|containerPath: /usr/bin|g" "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+    fi
+}
+
+# Create the nvidia runtime config, either snap default or custom #
+nvidia_runtime_config () {
+    RUNTIME_CONFIG_OVERRIDE="$(snapctl get nvidia-support.runtime.config-override)"
+
+    # Custom #
+    if [ -n "${RUNTIME_CONFIG_OVERRIDE}" ] ; then
+        echo "${RUNTIME_CONFIG_OVERRIDE}" > "${SNAP_DATA}/etc/nvidia-container-runtime/config.toml"
+    # Default - opinionated, but most viable option for now #
+    else
+        rm -f "${SNAP_DATA}/etc/nvidia-container-runtime/config.toml"
+        "${SNAP}/usr/bin/nvidia-ctk" config --in-place --set nvidia-container-runtime.mode=cdi --set nvidia-container-runtime.modes.cdi.spec-dirs="${SNAP_DATA}/etc/cdi" --config "${SNAP_DATA}/etc/nvidia-container-runtime/config.toml"
+    fi
+}
+
+# Generate the dockerd runtime config #
+docker_runtime_configure () {
+    "${SNAP}/usr/bin/nvidia-ctk" runtime configure --runtime=docker --runtime-path "${SNAP}/usr/bin/nvidia-container-runtime" --config "${SNAP_DATA}/config/daemon.json"
+}
+
+# Setup failure recovery #
+setup_fail () {
+    echo "WARNING: Conainter Toolkit setup seemed to fail with an error"
+
+    # Remove nvidia runtime config, if it exists #
+    jq -r 'del(.runtimes.nvidia)' "${SNAP_DATA}/config/daemon.json" > "${SNAP_DATA}/config/daemon.json.new"
+
+    # If it was removed [ there was a change ], copy in the new config, remove CDI config,  and set service restart flag #
+    if ! cmp "${SNAP_DATA}/config/daemon.json"{,.new} >/dev/null ; then
+        mv "${SNAP_DATA}/config/daemon.json"{.new,}
+        rm -f "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+        rm -f "${SNAP_DATA}/etc/nvidia-container-runtime/config.toml"
+    fi
+}
+
+# Info #
+setup_info () {
+    echo "Conainter Toolkit setup complete"
+}
+
+exit_inf () {
+    echo "INFO: ${1}"
+    exit 0
+}

--- a/nvidia/nvidia-container-toolkit
+++ b/nvidia/nvidia-container-toolkit
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -eu
+
+. "${SNAP}/usr/share/nvidia-container-toolkit/lib"
+
+# Connection hooks are run early - copy the config file from $SNAP into $SNAP_DATA if it doesn't exist
+if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
+  mkdir -p "$SNAP_DATA/config"
+  cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
+fi
+
+# Ensure hardware present #
+nvidia_hw_ensure
+
+# As service order is not guaranteed outside of snap - wait a bit for nvidia assemble to complete #
+device_wait /dev/nvidiactl || exit 0
+echo "NVIDIA ready"
+
+# Ensure the data dirs exist #
+ensure_nvidia_data_dirs
+
+# Setup nvidia support, but do not exit on failure #
+cdi_generate && nvidia_runtime_config && docker_runtime_configure && setup_info || setup_fail

--- a/nvidia/nvidia-container-toolkit-connect-hook
+++ b/nvidia/nvidia-container-toolkit-connect-hook
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script implements the connect hook for snap's graphics plugs
+. "${SNAP}/usr/share/nvidia-container-toolkit/lib"
+
+set -eux
+
+HOOK_LOG="${SNAP_COMMON}/hooks/${SNAP_REVISION}/$(basename "$0").log" && mkdir -p "${HOOK_LOG%/*}"
+exec &> >(tee -a "${HOOK_LOG}")
+
+. "${SNAP}/usr/share/nvidia-container-toolkit/lib"
+
+# Just exit if NVIDIA support is disabled #
+if nvidia_support_disabled; then
+    exit 0
+fi
+
+# Ensure hardware present #
+nvidia_hw_ensure
+
+# Restart services to reflect any changes if required #
+# If oneshot services are inactive they don't respond to restart, so stop/start #
+snapctl stop "${SNAP_NAME}.nvidia-container-toolkit"
+snapctl start --enable "${SNAP_NAME}.nvidia-container-toolkit"
+snapctl restart "${SNAP_NAME}.dockerd"

--- a/nvidia/system-detection
+++ b/nvidia/system-detection
@@ -1,0 +1,37 @@
+#!/bin/bash -u
+# Detect if nvidia support enabled, and available, for a system type #
+
+. "${SNAP}/usr/share/nvidia-container-toolkit/lib"
+
+# Just exit if NVIDIA support is disabled #
+if nvidia_support_disabled; then
+    exit_inf "NVIDIA support disabled by user"
+fi
+
+if nvidia_support_classic; then
+    echo "Running on Classic system"
+elif nvidia_support_core; then
+    echo "Running on Ubuntu Core system"
+else
+    exit_inf "No NVIDIA support detected. For NVIDIA support, please refer to https://github.com/canonical/docker-snap"
+fi
+
+## Running gpu-2404 wrapper for Core systems only ##
+
+# Classic does not require this wrapper #
+if nvidia_support_classic; then
+    exec "$@"
+fi
+
+if nvidia_support_core; then
+    if snapctl is-connected gpu-2404; then
+        exec "${SNAP}/gpu-2404/bin/gpu-2404-provider-wrapper" "$@"
+    fi
+
+    # Core 22 does not require this wrapper #
+    if snapctl is-connected graphics-core22  ; then
+        exec "$@"
+    fi
+
+    exit_inf "GPU user-space content provider not connected."
+fi

--- a/snap/hooks/connect-plug-gpu-2404
+++ b/snap/hooks/connect-plug-gpu-2404
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This hook runs when gpu-2404 content interface is connected
+
+set -eu
+
+echo "GPU-2404 content interface connected"
+
+# Check if NVIDIA hardware is present
+if lspci -d 10de: | grep -q 'NVIDIA Corporation'; then
+    echo "NVIDIA GPU detected: $(lspci -d 10de: | grep 'NVIDIA Corporation')"
+else
+    echo "No NVIDIA GPU detected"
+fi
+
+# Restart the listener service to pick up new GPU libraries
+if snapctl services "${SNAP_NAME}.listener" | grep -q "enabled"; then
+    snapctl restart "${SNAP_NAME}.listener" || true
+fi

--- a/snap/hooks/connect-plug-graphics-core22
+++ b/snap/hooks/connect-plug-graphics-core22
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This hook runs when graphics-core22 content interface is connected
+
+set -eu
+
+echo "Graphics-core22 content interface connected"
+
+# Check if NVIDIA hardware is present
+if lspci -d 10de: | grep -q 'NVIDIA Corporation'; then
+    echo "NVIDIA GPU detected: $(lspci -d 10de: | grep 'NVIDIA Corporation')"
+else
+    echo "No NVIDIA GPU detected"
+fi
+
+# Restart the listener service to pick up new GPU libraries
+if snapctl services "${SNAP_NAME}.listener" | grep -q "enabled"; then
+    snapctl restart "${SNAP_NAME}.listener" || true
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,18 +13,37 @@ platforms:
   amd64:
   arm64:
 
+plugs:
+  gpu-2404:
+    interface: content
+    target: $SNAP/gpu-2404
+    default-provider: mesa-2404
+  graphics-core22:
+    interface: content
+    target: $SNAP/graphics
+
 apps:
   ollama:
+    command-chain:
+      - bin/system-detection
+      - bin/gpu-wrapper
     command: bin/snap_launcher.sh
     plugs:
       - home
       - removable-media
       - network
       - network-bind
-      - opengl # grants also CUDA based GPU access
+      - opengl
+      - gpu-2404
+      - graphics-core22
     environment:
-      LD_LIBRARY_PATH: "$SNAP/lib/ollama:/var/lib/snapd/lib/gl${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+      LD_LIBRARY_PATH: "$SNAP/lib/ollama:$SNAP/gpu-2404/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:$SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+      LIBGL_DRIVERS_PATH: "$SNAP/gpu-2404/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri:$SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri"
+      LIBVA_DRIVERS_PATH: "$SNAP/gpu-2404/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri:$SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri"
   listener:
+    command-chain:
+      - bin/system-detection 
+      - bin/gpu-wrapper
     command: bin/snap_launcher.sh serve
     daemon: simple
     install-mode: enable
@@ -36,9 +55,13 @@ apps:
       - network
       - network-bind
       - opengl
+      - gpu-2404
+      - graphics-core22
     environment:
       NVIDIA_DRIVER_CAPABILITIES: compute,utility
-      LD_LIBRARY_PATH: "$SNAP/lib/ollama:/var/lib/snapd/lib/gl${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+      LD_LIBRARY_PATH: "$SNAP/lib/ollama:$SNAP/gpu-2404/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:$SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+      LIBGL_DRIVERS_PATH: "$SNAP/gpu-2404/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri:$SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri"
+      LIBVA_DRIVERS_PATH: "$SNAP/gpu-2404/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri:$SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri"
 
 parts:
   launcher:
@@ -46,6 +69,17 @@ parts:
     source: ./snap/local
     organize:
       snap_launcher.sh: bin/snap_launcher.sh
+
+  nvidia-toolkit:
+    plugin: dump
+    source: ./nvidia
+    organize:
+      lib: usr/share/nvidia-container-toolkit/lib
+      system-detection: bin/
+      gpu-wrapper: bin/
+    stage:
+      - bin/*
+      - usr/share/nvidia-container-toolkit/lib
 
   ollama:
     plugin: dump


### PR DESCRIPTION
- Add gpu-2404 content interface plug for modern GPU access
- Add graphics-core22 content interface for backward compatibility
- Implement NVIDIA GPU detection and library path setup
- Add connect hooks for GPU interface connections
- Update LD_LIBRARY_PATH to include GPU driver libraries
- Add NVIDIA wrapper scripts for GPU initialization
- Support both mesa-2404 and nvidia-core22 content providers

This enables Ollama to properly detect and use NVIDIA GPUs on Ubuntu Core 24 systems through the gpu-2404 interface while maintaining compatibility with Core 22 via graphics-core22.

Fixes GPU detection issues where Ollama was falling back to CPU-only inference despite GPU hardware being available.