### PR TITLE
Add configurable load timeout

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -9,3 +9,4 @@ snapctl set cuda-visible-devices=""
 snapctl set flash-attention=0
 snapctl set debug=0
 snapctl set context-length=""
+snapctl set load-timeout=""

--- a/snap/local/snap_launcher.sh
+++ b/snap/local/snap_launcher.sh
@@ -9,6 +9,7 @@ OLLAMA_FLASH_ATTENTION=$(snapctl get flash-attention)
 OLLAMA_DEBUG=$(snapctl get debug)
 OPTIONAL_CONTEXT_LENGTH=$(snapctl get context-length)
 OLLAMA_KEEP_ALIVE=$(snapctl get keep-alive)
+OPTIONAL_LOAD_TIMEOUT=$(snapctl get load-timeout)
 
 if [ -n "$CUDA_VISIBLE_DEVICES_VALUE" ]; then
     export CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES_VALUE
@@ -20,6 +21,10 @@ fi
 
 if [ -n "$OLLAMA_KEEP_ALIVE" ]; then
     export OLLAMA_KEEP_ALIVE
+fi
+
+if [ -n "$OPTIONAL_LOAD_TIMEOUT" ]; then
+    export OLLAMA_LOAD_TIMEOUT=$OPTIONAL_LOAD_TIMEOUT
 fi
 
 export OLLAMA_HOST OLLAMA_MODELS OLLAMA_ORIGINS OLLAMA_DEBUG


### PR DESCRIPTION
## Summary
- Add a `load-timeout` snap config option that maps to ollama's `OLLAMA_LOAD_TIMEOUT` environment variable.
- Defaults to empty in the `install` hook, so ollama's built-in default applies when unset.
- The launcher reads `load-timeout` and exports `OLLAMA_LOAD_TIMEOUT` only when set, matching the optional-config pattern used for `context-length` and `keep-alive`.

## Usage
```
snap set ollama load-timeout=600
```
A plain numeric value is interpreted as seconds; Go duration strings (`30s`, `10m`, `1h`) are also accepted. Zero or a negative value makes the timeout infinite. The default is 5 minutes. Takes effect on the next daemon restart (handled by the `configure` hook).

## References
- [`OLLAMA_LOAD_TIMEOUT` in the `envconfig` package docs](https://pkg.go.dev/github.com/ollama/ollama/envconfig#LoadTimeout)
- [`envconfig/config.go` source](https://github.com/ollama/ollama/blob/main/envconfig/config.go)